### PR TITLE
Speed Optimisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,33 @@ cd cmd/largesort
 ```
 
 ## Improvements
-- intermediate files are currently text. Reading and writing will be much 
-faster if we use binary files
-- Only two files are merged at a time. We could speed this up by
-using `runtime.NumCPU()` goroutines to merge simultaneously.
-- The first parse spilts the input file into small sorted chunks. At the
-moment we wait until this has completed before we start the merge phase.
-But we can start merging as soon as there are two chunks available.
+- using 32 bit binary for intermediate files
+- using unsafe casts to read and write files directly into []int64 without going through 
+binary.LittleEndian
+- run merges in parralel
+- initially we waited for the initial leafSort pass to complete before starting merging the chunks.
+We now start merging as soon as the first two chunks have been written.
+- use int32 rather than int64, halving the amnount of disk io.
+
+This speeds up sort time by a factor of 3.
+
+### Before the changes
+```
+generating 10000000 random numbers
+running largesort
+real	0m17.807s
+user	0m14.183s
+sys	0m2.845s
+```
+
+### After the changes
+```
+generating 10000000 random numbers
+running largesort
+real	0m6.548s
+user	0m5.716s
+sys	0m1.191s
+```
+
+## TODO
+We should probably limit the number of active goroutines to the number of cores on the machine.

--- a/msort_test.go
+++ b/msort_test.go
@@ -20,13 +20,13 @@ func Test_astream_Next(t *testing.T) {
 	assert.True(t, ok)
 	assert.False(t, a.eof)
 	assert.NoError(t, a.err)
-	assert.Equal(t, int64(1), a.top)
+	assert.Equal(t, int32(1), a.top)
 
 	ok = a.Next()
 	assert.True(t, ok)
 	assert.False(t, a.eof)
 	assert.NoError(t, a.err)
-	assert.Equal(t, int64(2), a.top)
+	assert.Equal(t, int32(2), a.top)
 
 	ok = a.Next()
 	assert.False(t, ok)
@@ -45,34 +45,34 @@ func Test_astream_NextError(t *testing.T) {
 
 func Test_astream_ReadNums(t *testing.T) {
 	a := newAStream(strings.NewReader("1\n2\n3\n"))
-	nums := make([]int64, 2)
+	nums := make([]int32, 2)
 	n, err := a.ReadNums(nums)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
-	assert.Equal(t, []int64{1, 2}, nums)
+	assert.Equal(t, []int32{1, 2}, nums)
 
 	n, err = a.ReadNums(nums)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n)
-	assert.Equal(t, int64(3), nums[0])
+	assert.Equal(t, int32(3), nums[0])
 
 }
 
 func Test_astream_ReadNumsError(t *testing.T) {
 	a := newAStream(strings.NewReader("abc"))
-	nums := make([]int64, 2)
+	nums := make([]int32, 2)
 	_, err := a.ReadNums(nums)
 	assert.Error(t, err)
 }
 
 func Test_astream_ReadNumsErrorBadFile(t *testing.T) {
 	a := newAStream(errorReader(0))
-	nums := make([]int64, 2)
+	nums := make([]int32, 2)
 	_, err := a.ReadNums(nums)
 	assert.Error(t, err)
 }
 
-func encode(val ...int64) []byte {
+func encode(val ...int32) []byte {
 	a := &bytes.Buffer{}
 	for _, x := range val {
 		writeBInt(a, x)
@@ -149,7 +149,7 @@ func checkContent(t *testing.T, expected interface{}, fn string) {
 	}
 }
 
-//leafSort(r io.Reader, chunkSz int, chunks chan string, errors chan error, inFlight *int64)
+//leafSort(r io.Reader, chunkSz int, chunks chan string, errors chan error, inFlight *int32)
 func Test_leafSort(t *testing.T) {
 	var err error
 	tmpDir, err = ioutil.TempDir(".", "tempdir")
@@ -158,7 +158,7 @@ func Test_leafSort(t *testing.T) {
 	s := "10 8 6 4 2 0 1 3 7 9 99"
 	files := make(chan string)
 	errors := make(chan error)
-	inFlight := int64(1)
+	inFlight := int32(1)
 	go leafSort(strings.NewReader(s), 4, files, errors, &inFlight)
 
 	chunk := <-files
@@ -180,7 +180,7 @@ func Test_leafSort0(t *testing.T) {
 	s := "10 8 6 4 2"
 	files := make(chan string)
 	errors := make(chan error)
-	inFlight := int64(1)
+	inFlight := int32(1)
 	go leafSort(strings.NewReader(s), 4, files, errors, &inFlight)
 
 	chunk := <-files
@@ -199,7 +199,7 @@ func Test_leafSortError(t *testing.T) {
 	s := "10 8 6 4 2 0 1 3 5 7 9  not_a_number"
 	files := make(chan string, 10)
 	errors := make(chan error)
-	inFlight := int64(1)
+	inFlight := int32(1)
 	go leafSort(strings.NewReader(s), 4, files, errors, &inFlight)
 	err = <-errors
 	assert.Error(t, err)
@@ -288,7 +288,7 @@ func Test_iStream_NextEmpty(t *testing.T) {
 func Test_writeBInt(t *testing.T) {
 	h := &bytes.Buffer{}
 	writeBInt(h, 0x7)
-	assert.Equal(t, []byte{0x7, 0, 0, 0, 0, 0, 0, 0}, h.Bytes())
+	assert.Equal(t, []byte{0x7, 0, 0, 0}, h.Bytes())
 }
 
 func Test_ReadBInt(t *testing.T) {
@@ -298,12 +298,12 @@ func Test_ReadBInt(t *testing.T) {
 	assert.True(t, ok)
 	assert.False(t, b.eof)
 	assert.NoError(t, b.err)
-	assert.Equal(t, int64(7), b.top)
+	assert.Equal(t, int32(7), b.top)
 }
 
 func Test_writeBInts(t *testing.T) {
 	f := &bytes.Buffer{}
-	err := writeBInts(f, []int64{1})
+	err := writeBInts(f, []int32{1})
 	assert.NoError(t, err)
 	assert.Equal(t, encode(1), f.Bytes())
 }
@@ -328,29 +328,29 @@ func Test_intWriter_Write3(t *testing.T) {
 
 func Test_readBInts(t *testing.T) {
 	buf := bytes.NewBuffer(encode(1, 2, 3))
-	a := make([]int64, 3)
+	a := make([]int32, 3)
 	got, err := readBInts(buf, a)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, got)
-	assert.Equal(t, []int64{1, 2, 3}, a)
+	assert.Equal(t, []int32{1, 2, 3}, a)
 }
 
 func Test_readBIntsShort(t *testing.T) {
 	buf := bytes.NewBuffer(encode(1, 2, 3))
-	a := make([]int64, 2)
+	a := make([]int32, 2)
 	got, err := readBInts(buf, a)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, got)
-	assert.Equal(t, []int64{1, 2}, a)
+	assert.Equal(t, []int32{1, 2}, a)
 }
 
 func Test_readBIntsEof(t *testing.T) {
 	buf := bytes.NewBuffer(encode(1, 2, 3))
-	a := make([]int64, 4)
+	a := make([]int32, 4)
 	got, err := readBInts(buf, a)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, got)
-	assert.Equal(t, []int64{1, 2, 3}, a[0:got])
+	assert.Equal(t, []int32{1, 2, 3}, a[0:got])
 
 	got, err = readBInts(buf, a)
 	assert.Error(t, err)

--- a/msort_test.go
+++ b/msort_test.go
@@ -116,15 +116,22 @@ func (_ errorReader) Read(_ []byte) (int, error) {
 
 func Test_doMergeErrorOutput(t *testing.T) {
 	var out errorWriter
-	r1 := strings.NewReader("1 3 5")
-	r2 := strings.NewReader("2 4")
+	r1 := bytes.NewReader(encode(1))
+	r2 := bytes.NewReader(encode(2))
 	err := doMerge(out, r1, r2)
 	assert.Error(t, err)
 }
 
 func Test_doMergeErrorInput(t *testing.T) {
 	r1 := errorReader(0)
-	r2 := strings.NewReader("2 4")
+	r2 := bytes.NewReader(encode(1, 2, 3))
+	err := doMerge(ioutil.Discard, r1, r2)
+	assert.Error(t, err)
+}
+
+func Test_doMergeTruncatedInput(t *testing.T) {
+	r1 := bytes.NewReader([]byte{1, 2, 3, 4, 5, 6})
+	r2 := bytes.NewReader(encode(1, 2, 3))
 	err := doMerge(ioutil.Discard, r1, r2)
 	assert.Error(t, err)
 }

--- a/msort_test.go
+++ b/msort_test.go
@@ -73,7 +73,7 @@ func Test_astream_ReadNumsErrorBadFile(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func encode(val... int64)[]byte {
+func encode(val ...int64) []byte {
 	a := &bytes.Buffer{}
 	for _, x := range val {
 		writeBInt(a, x)
@@ -86,7 +86,7 @@ func Test_doMerge(t *testing.T) {
 	r1 := bytes.NewReader(encode(1, 3, 5))
 	r2 := bytes.NewReader(encode(2, 4))
 	doMerge(out, r1, r2)
-	assert.Equal(t, encode(1,2,3,4,5), out.Bytes())
+	assert.Equal(t, encode(1, 2, 3, 4, 5), out.Bytes())
 }
 
 func Test_doMergeOneToOne(t *testing.T) {
@@ -94,9 +94,8 @@ func Test_doMergeOneToOne(t *testing.T) {
 	r1 := bytes.NewReader(encode(1))
 	r2 := bytes.NewReader(encode(2))
 	doMerge(out, r1, r2)
-	assert.Equal(t, encode(1,2), out.Bytes())
+	assert.Equal(t, encode(1, 2), out.Bytes())
 }
-
 
 func Test_doMergeBadInputFile(t *testing.T) {
 	err := doMerge(ioutil.Discard, errorReader(0), errorReader(0))
@@ -153,9 +152,9 @@ func Test_leafSort(t *testing.T) {
 	gotChunks, err := leafSort(strings.NewReader(s), 4)
 	assert.NoError(t, err)
 	require.Equal(t, 3, len(gotChunks))
-	checkContent(t, encode(4,6,8,10), gotChunks[0])
-	checkContent(t, encode(0,1,2,3), gotChunks[1])
-	checkContent(t, encode(7,9, 99), gotChunks[2])
+	checkContent(t, encode(4, 6, 8, 10), gotChunks[0])
+	checkContent(t, encode(0, 1, 2, 3), gotChunks[1])
+	checkContent(t, encode(7, 9, 99), gotChunks[2])
 }
 
 func Test_leafSort0(t *testing.T) {
@@ -167,7 +166,7 @@ func Test_leafSort0(t *testing.T) {
 	gotChunks, err := leafSort(strings.NewReader(s), 4)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(gotChunks))
-	checkContent(t, encode(4,6,8,10), gotChunks[0])
+	checkContent(t, encode(4, 6, 8, 10), gotChunks[0])
 	checkContent(t, encode(2), gotChunks[1])
 }
 
@@ -180,7 +179,7 @@ func Test_leafSort1(t *testing.T) {
 	gotChunks, err := leafSort(strings.NewReader(s), 4)
 	assert.NoError(t, err)
 	require.Equal(t, 2, len(gotChunks))
-	checkContent(t, encode(4,6,8,10), gotChunks[0])
+	checkContent(t, encode(4, 6, 8, 10), gotChunks[0])
 }
 func Test_leafSort2(t *testing.T) {
 	var err error
@@ -291,11 +290,11 @@ func Test_iStream_NextEmpty(t *testing.T) {
 func Test_writeBInt(t *testing.T) {
 	h := &bytes.Buffer{}
 	writeBInt(h, 0x7)
-	assert.Equal(t, []byte{0xe}, h.Bytes())
+	assert.Equal(t, []byte{0x7, 0, 0, 0, 0, 0, 0, 0}, h.Bytes())
 }
 
 func Test_ReadBInt(t *testing.T) {
-	h := bytes.NewReader([]byte{0xe})
+	h := bytes.NewReader([]byte{0x7, 0, 0, 0, 0, 0, 0, 0})
 	b := newIStream(h)
 	ok := b.Next()
 	assert.True(t, ok)
@@ -303,4 +302,3 @@ func Test_ReadBInt(t *testing.T) {
 	assert.NoError(t, b.err)
 	assert.Equal(t, int64(7), b.top)
 }
-


### PR DESCRIPTION
- intermediate files are currently text. Reading and writing will be much 	- using 32 bit binary for intermediate files
faster if we use binary files	- using unsafe casts to read and write files directly into []int64 without going through 
- Only two files are merged at a time. We could speed this up by	binary.LittleEndian
using `runtime.NumCPU()` goroutines to merge simultaneously.	- run merges in parralel
- The first parse spilts the input file into small sorted chunks. At the	- initially we waited for the initial leafSort pass to complete before starting merging the chunks.
moment we wait until this has completed before we start the merge phase.	We now start merging as soon as the first two chunks have been written.
But we can start merging as soon as there are two chunks available.	- use int32 rather than int64, halving the amnount of disk io.

This speeds up sort time by a factor of 3.

### Before the changes
```
generating 10000000 random numbers
running largesort
real	0m17.807s
user	0m14.183s
sys	0m2.845s
```

### After the changes
```
generating 10000000 random numbers
running largesort
real	0m6.548s
user	0m5.716s
sys	0m1.191s
```
